### PR TITLE
Tanuh: UAT instance of the physician app on the same node (avni-infra#98)

### DIFF
--- a/configure/Makefile
+++ b/configure/Makefile
@@ -245,6 +245,18 @@ tanuh-webapp-prod: check-vault-pwd-file
 		--vault-password-file ${VAULT_PASSWORD_FILE} \
 		--tags tanuh_webapp $(EXTRA_ARGS)
 
+# UAT physician app on the SAME Tanuh EC2 host (uat-tanuh.avniproject.org, :8081).
+# Deploys ONLY the tanuh_webapp_uat-tagged role application; the prod webapp and
+# Metabase are never touched (the UAT role is guarded by `when: 'tanuh_webapp_uat'
+# in ansible_run_tags`, so prod/untagged runs skip it). AWS wiring is one-shot —
+# run once before the first UAT deploy:
+#   WEBAPP_HOSTNAME=uat-tanuh.avniproject.org TG_NAME=tanuh-webapp-uat TG_PORT=8081 LISTENER_PRIORITY=32 bash ../tanuh-webapp/aws_alb_setup.sh
+# UAT tracks main; override with EXTRA_ARGS='-e tanuh_webapp_git_ref=<ref>'.
+tanuh-webapp-uat: check-vault-pwd-file
+	ansible-playbook prod_tanuh_metabase_servers.yml -i inventory/prod \
+		--vault-password-file ${VAULT_PASSWORD_FILE} \
+		--tags tanuh_webapp_uat $(EXTRA_ARGS)
+
 metabase-schedule-protection: check-vault-pwd-file
 	ansible-playbook -i inventory/staging staging_metabase_servers.yml --tags "metabase_db_trigger_2" --vault-password-file ${VAULT_PASSWORD_FILE}
 

--- a/configure/prod_tanuh_metabase_servers.yml
+++ b/configure/prod_tanuh_metabase_servers.yml
@@ -25,4 +25,23 @@
     - ecr_docker_auth
     - metabase
     - tanuh_maintenance
-    - tanuh_webapp
+    # Prod physician app (tanuh.avniproject.org, :8080). Deployed by
+    # `make tanuh-webapp-prod` (--tags tanuh_webapp) and by any untagged run of
+    # this playbook (e.g. `make tanuh-metabase-prod`) — unchanged behaviour.
+    - role: tanuh_webapp
+      tags: [tanuh_webapp]
+    # UAT physician app (uat-tanuh.avniproject.org, :8081) on the SAME host,
+    # backed by the Tanuh_UAT org on prod Avni. Guarded so it deploys ONLY when
+    # `tanuh_webapp_uat` is explicitly requested (`make tanuh-webapp-uat`):
+    #   - `--tags tanuh_webapp` (prod deploy)  -> not selected -> skipped
+    #   - untagged run (`make tanuh-metabase-prod`, ansible_run_tags == ['all'])
+    #     -> selected by tag but `when` is false -> skipped
+    # so the prod webapp / metabase are never touched by the UAT instance.
+    - role: tanuh_webapp
+      vars:
+        tanuh_webapp_instance_name: tanuh-webapp-uat
+        tanuh_webapp_listen_port: 8081
+        tanuh_webapp_server_name: uat-tanuh.avniproject.org
+        tanuh_webapp_git_ref: main
+      tags: [tanuh_webapp_uat]
+      when: "'tanuh_webapp_uat' in ansible_run_tags"

--- a/configure/roles/tanuh_webapp/defaults/main.yml
+++ b/configure/roles/tanuh_webapp/defaults/main.yml
@@ -2,9 +2,14 @@
 
 tanuh_webapp_repo_url: https://github.com/avniproject/tanuh-webapp.git
 tanuh_webapp_git_ref: main
-tanuh_webapp_build_user: tanuh-webapp
-tanuh_webapp_build_dir: /var/lib/tanuh-webapp-build
-tanuh_webapp_docroot: /var/www/tanuh-webapp
+# Instance name isolates a second (UAT) deployment on the same host. For the
+# default (`tanuh-webapp`) every derived path below resolves to the exact
+# pre-existing prod value, so the prod instance is byte-identical. The UAT
+# invocation overrides this to `tanuh-webapp-uat`.
+tanuh_webapp_instance_name: tanuh-webapp
+tanuh_webapp_build_user: "{{ tanuh_webapp_instance_name }}"
+tanuh_webapp_build_dir: "/var/lib/{{ tanuh_webapp_instance_name }}-build"
+tanuh_webapp_docroot: "/var/www/{{ tanuh_webapp_instance_name }}"
 tanuh_webapp_node_major: "24"
 # Same-origin model: bundle calls relative paths (/idp-details, /api, etc.),
 # nginx reverse-proxies them upstream to `tanuh_webapp_avni_proxy_target`. So

--- a/configure/roles/tanuh_webapp/tasks/main.yml
+++ b/configure/roles/tanuh_webapp/tasks/main.yml
@@ -11,21 +11,18 @@
       - dnsutils   # dig, used by the upstream DNS watchdog
     state: present
     update_cache: "{{ update_apt_cache | default(false) }}"
-  tags: tanuh_webapp
 
 - name: Disable nginx default site
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
   notify: reload nginx tanuh_webapp
-  tags: tanuh_webapp
 
 - name: Ensure nginx is started and enabled
   service:
     name: nginx
     state: started
     enabled: yes
-  tags: tanuh_webapp
 
 # Host firewall: the `security` role's `ufw_allowed_ports` list on this host
 # only covers 22/80/443/3000/8021/8023. The ALB targets us on 8080, so without
@@ -35,7 +32,6 @@
     rule: allow
     port: "{{ tanuh_webapp_listen_port }}"
     proto: tcp
-  tags: tanuh_webapp
 
 - name: Ensure tanuh-webapp build user exists
   user:
@@ -44,14 +40,12 @@
     shell: /bin/bash
     create_home: yes
     state: present
-  tags: tanuh_webapp
 
 - name: Check installed Node major version
   command: node --version
   register: tanuh_webapp_node_version
   changed_when: false
   failed_when: false
-  tags: tanuh_webapp
 
 - name: Install NodeSource apt repository for Node {{ tanuh_webapp_node_major }}
   shell: |
@@ -61,7 +55,6 @@
     executable: /bin/bash
   when: tanuh_webapp_node_version.rc != 0
         or not tanuh_webapp_node_version.stdout.startswith('v' ~ tanuh_webapp_node_major ~ '.')
-  tags: tanuh_webapp
 
 - name: Install Node.js
   apt:
@@ -70,7 +63,6 @@
     update_cache: yes
   when: tanuh_webapp_node_version.rc != 0
         or not tanuh_webapp_node_version.stdout.startswith('v' ~ tanuh_webapp_node_major ~ '.')
-  tags: tanuh_webapp
 
 - name: Ensure build dir exists (owned by build user)
   file:
@@ -79,7 +71,6 @@
     group: "{{ tanuh_webapp_build_user }}"
     state: directory
     mode: '0755'
-  tags: tanuh_webapp
 
 - name: Ensure docroot exists (owned by www-data)
   file:
@@ -88,7 +79,6 @@
     group: www-data
     state: directory
     mode: '0755'
-  tags: tanuh_webapp
 
 - name: Checkout tanuh-webapp source at {{ tanuh_webapp_git_ref }}
   git:
@@ -98,7 +88,6 @@
     force: yes
   become_user: "{{ tanuh_webapp_build_user }}"
   register: tanuh_webapp_git
-  tags: tanuh_webapp
 
 - name: Render .env.production
   template:
@@ -108,7 +97,6 @@
     group: "{{ tanuh_webapp_build_user }}"
     mode: '0644'
   register: tanuh_webapp_env
-  tags: tanuh_webapp
 
 - name: npm ci
   command: npm ci
@@ -118,7 +106,6 @@
   when: tanuh_webapp_git.changed
         or tanuh_webapp_env.changed
         or not (lookup('ansible.builtin.fileglob', tanuh_webapp_build_dir + '/node_modules/.package-lock.json'))
-  tags: tanuh_webapp
 
 - name: npm run build
   command: npm run build
@@ -129,7 +116,6 @@
     NODE_ENV: production
   when: tanuh_webapp_git.changed or tanuh_webapp_env.changed
   register: tanuh_webapp_build
-  tags: tanuh_webapp
 
 - name: Force a build when docroot is empty
   command: npm run build
@@ -141,7 +127,6 @@
   when:
     - not (tanuh_webapp_build.changed | default(false))
     - not (lookup('ansible.builtin.fileglob', tanuh_webapp_docroot + '/index.html'))
-  tags: tanuh_webapp
 
 - name: Sync dist/ -> docroot (atomic-ish, --delete to drop removed files)
   command: >
@@ -150,30 +135,26 @@
     {{ tanuh_webapp_docroot }}/
   register: tanuh_webapp_sync
   changed_when: "'>f' in tanuh_webapp_sync.stdout or 'cd' in tanuh_webapp_sync.stdout or 'deleting' in tanuh_webapp_sync.stdout"
-  tags: tanuh_webapp
 
 - name: Install nginx server block
   template:
     src: nginx-tanuh-webapp.conf.j2
-    dest: /etc/nginx/sites-available/tanuh-webapp.conf
+    dest: /etc/nginx/sites-available/{{ tanuh_webapp_instance_name }}.conf
     owner: root
     group: root
     mode: '0644'
   notify: reload nginx tanuh_webapp
-  tags: tanuh_webapp
 
 - name: Enable nginx server block
   file:
-    src: /etc/nginx/sites-available/tanuh-webapp.conf
-    dest: /etc/nginx/sites-enabled/tanuh-webapp.conf
+    src: /etc/nginx/sites-available/{{ tanuh_webapp_instance_name }}.conf
+    dest: /etc/nginx/sites-enabled/{{ tanuh_webapp_instance_name }}.conf
     state: link
   notify: reload nginx tanuh_webapp
-  tags: tanuh_webapp
 
 - name: Validate nginx config
   command: nginx -t
   changed_when: false
-  tags: tanuh_webapp
 
 # nginx resolves the upstream{} hostname once at config load. The Avni ALB's
 # IPs rotate, so a watchdog reloads nginx (re-resolving DNS) whenever the
@@ -186,11 +167,9 @@
     owner: root
     group: root
     mode: '0755'
-  tags: tanuh_webapp
 
 - name: Schedule nginx upstream DNS watchdog
   cron:
     name: nginx upstream dns watch
     user: root
     job: /usr/local/bin/nginx-upstream-dns-watch.sh
-  tags: tanuh_webapp

--- a/configure/roles/tanuh_webapp/templates/nginx-tanuh-webapp.conf.j2
+++ b/configure/roles/tanuh_webapp/templates/nginx-tanuh-webapp.conf.j2
@@ -1,9 +1,14 @@
 {% set _proxy_host = tanuh_webapp_avni_proxy_target | regex_replace('^https?://', '') | regex_replace('/.*$', '') %}
+{# Per-instance suffix so a second (UAT) instance sharing this nginx does not
+   collide on the http-context `upstream`/`log_format` names (nginx rejects
+   duplicates). The default instance (`tanuh-webapp` = prod) keeps the
+   unqualified names, so its rendered config stays byte-identical. #}
+{% set _sfx = '' if (tanuh_webapp_instance_name | default('tanuh-webapp')) == 'tanuh-webapp' else '_' + (tanuh_webapp_instance_name | replace('-', '_')) %}
 # Keepalive pool to the upstream Avni server. Without this, every /api, /me,
 # /idp-details call from the SPA opens a fresh TLS connection to the upstream,
 # which adds a 200-400ms handshake to first-paint when the SPA fires several
 # bootstrap requests in parallel.
-upstream avni_backend {
+upstream avni_backend{{ _sfx }} {
     server {{ _proxy_host }}:443;
     keepalive 32;
     # Close idle pooled connections before the upstream ALB does (ALB idle
@@ -13,7 +18,7 @@ upstream avni_backend {
 
 # Upstream timing per request: uct≈connect (5s spikes = dead/rotated ALB IP,
 # see the dns-watch cron), urt≈Avni server time. One grep diagnoses a stall.
-log_format avni_upstream '$remote_addr [$time_local] "$request" $status '
+log_format avni_upstream{{ _sfx }} '$remote_addr [$time_local] "$request" $status '
                          'rt=$request_time uct=$upstream_connect_time '
                          'uht=$upstream_header_time urt=$upstream_response_time '
                          'peer=$upstream_addr';
@@ -32,8 +37,8 @@ server {
     # them as same-origin and CORS is not required. The path set mirrors the
     # Vite dev-server proxy in vite.config.ts.
     location ~ ^/(idp-details|api|me|web|media|cognito-details)(/|$) {
-        access_log /var/log/nginx/tanuh-webapp-upstream.log avni_upstream;
-        proxy_pass https://avni_backend;
+        access_log /var/log/nginx/{{ tanuh_webapp_instance_name }}-upstream.log avni_upstream{{ _sfx }};
+        proxy_pass https://avni_backend{{ _sfx }};
         proxy_http_version 1.1;
         # nginx freezes the upstream{} peer IPs at config load; when the ALB
         # rotates an IP away, a request landing on the dead peer must fail in

--- a/tanuh-webapp/README.md
+++ b/tanuh-webapp/README.md
@@ -75,6 +75,64 @@ Re-runs are cheap: `npm ci` skips when `node_modules/.package-lock.json` is
 already present and the git HEAD hasn't moved; `npm run build` runs only when
 the source or `.env.production` changed.
 
+## UAT instance (same node)
+
+A second, isolated instance of the physician app runs on the **same** Tanuh
+Reporting EC2 for pre-production validation, at
+`https://uat-tanuh.avniproject.org` (nginx `:8081`). It proxies to the same prod
+Avni backend; data isolation is at the **org** level — UAT testers log in with
+`Tanuh_UAT`-org accounts and only touch UAT data. Use it to validate a change
+before promoting the prod instance.
+
+```
+Browser ─► uat-tanuh.avniproject.org ─► reporting-alb:443 (its own SNI cert)
+                                          └─ Host: uat-tanuh.avniproject.org ──► tanuh-webapp-uat TG ──► EC2:8081 (nginx → /var/www/tanuh-webapp-uat)
+```
+
+Same `tanuh_webapp` role, instantiated with
+`tanuh_webapp_instance_name: tanuh-webapp-uat` (→ docroot
+`/var/www/tanuh-webapp-uat`, build dir `/var/lib/tanuh-webapp-uat-build`, nginx
+`tanuh-webapp-uat.conf`, port 8081).
+
+### One-time UAT AWS wiring
+
+Run once, from this directory, before the first UAT deploy:
+
+```bash
+WEBAPP_HOSTNAME=uat-tanuh.avniproject.org \
+TG_NAME=tanuh-webapp-uat TG_PORT=8081 LISTENER_PRIORITY=32 \
+bash aws_alb_setup.sh
+```
+
+Provisions (additively — the prod wiring at priority 31 is untouched):
+
+- ACM cert for `uat-tanuh.avniproject.org` (DNS-validated; its own SNI cert on the shared 443 listener).
+- Target group `tanuh-webapp-uat` (HTTP/8081, health `GET /`).
+- Listener rule **priority 32**, host-header `uat-tanuh.avniproject.org` → TG.
+- Security group ingress on `tanuh-metabase-sg`: 8081/tcp from the ALB SG.
+- Route53 ALIAS `uat-tanuh.avniproject.org` → `reporting-alb`.
+
+Not idempotent. To undo (same UAT env):
+
+```bash
+WEBAPP_HOSTNAME=uat-tanuh.avniproject.org TG_NAME=tanuh-webapp-uat TG_PORT=8081 LISTENER_PRIORITY=32 bash aws_alb_teardown.sh
+```
+
+### UAT deploy
+
+```bash
+cd ../configure
+VAULT_PASSWORD_FILE=~/.ssh/infra-valut-pwd-file make tanuh-webapp-uat
+```
+
+Runs only the `tanuh_webapp_uat`-tagged role application against
+`prod_tanuh_metabase_servers.yml`. The prod webapp, Metabase and Superset on the
+same host are **not** touched: the UAT role is guarded by
+`when: 'tanuh_webapp_uat' in ansible_run_tags`, so `make tanuh-webapp-prod` and
+untagged runs (`make tanuh-metabase-prod`) skip it entirely. UAT tracks `main`;
+deploy a specific ref with
+`make tanuh-webapp-uat EXTRA_ARGS='-e tanuh_webapp_git_ref=<ref>'`.
+
 ## Pinning a release
 
 By default the role builds from `main`. To pin to a tag or commit SHA, set


### PR DESCRIPTION
## What & why
Adds a UAT instance of the Tanuh physician app on the **same** Tanuh reporting EC2, so physician-app changes get validated at `uat-tanuh.avniproject.org` before the live `tanuh.avniproject.org` moves.

Epic: avniproject/avni-product#1889 · **Closes #98** · addresses the doc portion of #99 (the live `aws_alb_setup.sh` UAT run and the `tanuh-webapp` git tagging in #1 remain separate ops steps).

## Approach — no prod impact
- Parameterize the `tanuh_webapp` role with `tanuh_webapp_instance_name`. For the default (`tanuh-webapp`) every derived path resolves to the **exact pre-existing prod value**, so the prod instance is byte-identical.
- Move the per-task `tanuh_webapp` tags to the role-application level; apply the role twice in `prod_tanuh_metabase_servers.yml`.
- The UAT role-application is guarded by `when: "'tanuh_webapp_uat' in ansible_run_tags"`, so:
  - `make tanuh-webapp-prod` (`--tags tanuh_webapp`) → UAT not selected → skipped
  - untagged runs (`make tanuh-metabase-prod`, `ansible_run_tags == ['all']`) → selected by tag but `when` is false → skipped
  - `make tanuh-webapp-uat` (`--tags tanuh_webapp_uat`) → UAT deploys
- New `make tanuh-webapp-uat` target; UAT deploy + one-time ALB wiring documented in `tanuh-webapp/README.md`.

## Verification (static — no connection to the prod node)
- `ansible-playbook … --syntax-check` passes.
- `ansible-playbook … --list-tasks --tags tanuh_webapp` is **byte-identical** to the pre-change baseline → `make tanuh-webapp-prod` selection is unchanged.
- `--list-tasks --tags tanuh_webapp_uat` selects the 21 UAT tasks (tagged `tanuh_webapp_uat`).
- The role is referenced by no other playbook.

Deploy-time ACs (`curl localhost:8081 → 200`, ALB target health, prod re-deploy `changed=0`) are confirmed when the operator runs `make tanuh-webapp-uat` — **intentionally not run here to avoid touching prod**.

## Follow-ons (not in this PR)
- One-time UAT ALB wiring (#99): `WEBAPP_HOSTNAME=uat-tanuh.avniproject.org TG_NAME=tanuh-webapp-uat TG_PORT=8081 LISTENER_PRIORITY=32 bash tanuh-webapp/aws_alb_setup.sh`
- `tanuh-webapp` git tagging + prod tag-pin (#1)

## Note
`tanuh-webapp/README.md` has some **pre-existing** staleness (it still describes a cross-origin `staging.avniproject.org` + CORS model, whereas the role now uses same-origin proxy to `app.avniproject.org`). Left as-is — out of scope for this change.
